### PR TITLE
Add The Mind's I as currently reading

### DIFF
--- a/readings.csv
+++ b/readings.csv
@@ -1,4 +1,5 @@
 title,author,type,category,subject,topic,status,startedAt,completedAt,rating,notes
+"The Mind's I: Fantasies and Reflections on Self & Soul","Douglas R. Hofstadter, Daniel C. Dennett",book,non-fiction,philosophy,,reading,April 3rd 2026,,,
 Tractatus Logico-Philosophicus,Ludwig Wittgenstein,book,non-fiction,philosophy,,rereading,March 26th 2026,,,
 "Wittgenstein's Poker: The Story of a Ten-Minute Argument Between Two Great Philosophers","David Edmonds, John Eidinow",book,non-fiction,philosophy,,completed,,March 22nd 2026,,
 Intuition Pumps and Other Tools for Thinking,Daniel C. Dennett,book,non-fiction,philosophy,,completed,August 5th 2025,March 24th 2026,,


### PR DESCRIPTION
## Summary
- Add *The Mind's I: Fantasies and Reflections on Self & Soul* by Douglas R. Hofstadter and Daniel C. Dennett as currently reading (started April 3rd 2026)

https://claude.ai/code/session_01EjxL3pZqwxN3izA7VvLCcw